### PR TITLE
TFP-4867 regler for avslag av perioder dersom påbegynt ny svp/fp-sak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jacoco.version>0.8.7</jacoco.version>
-        <fpsak.nare.version>2.1.5</fpsak.nare.version>
+        <fpsak.nare.version>2.2.0</fpsak.nare.version>
         <fpsak.tidsserie.version>2.5.8</fpsak.tidsserie.version>
         <assertj.version>3.22.0</assertj.version>
     </properties>

--- a/src/main/java/no/nav/svangerskapspenger/domene/resultat/PeriodeIkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/svangerskapspenger/domene/resultat/PeriodeIkkeOppfyltÅrsak.java
@@ -9,7 +9,8 @@ public enum PeriodeIkkeOppfyltÅrsak implements PeriodeÅrsak {
     PERIODEN_ER_IKKE_FØR_FØDSEL(8309, "Perioden er ikke før fødsel"),
     PERIODEN_MÅ_SLUTTE_SENEST_TRE_UKER_FØR_TERMIN(8310, "Perioden må slutte senest tre uker før termin"),
     PERIODEN_ER_SAMTIDIG_SOM_EN_FERIE(8311, "Perioden er samtidig som en ferie"),
-    PERIODEN_ER_ETTER_ET_OPPHOLD_I_UTTAK(8313, "Perioden er etter et opphold i uttak");
+    PERIODEN_ER_ETTER_ET_OPPHOLD_I_UTTAK(8313, "Perioden er etter et opphold i uttak"),
+    BEGYNT_ANNEN_SAK(8314, "Perioden er etter startdato annen sak/stønadsperiode");
 
     private final int id;
     private final String beskrivelse;

--- a/src/main/java/no/nav/svangerskapspenger/domene/søknad/AvklarteDatoer.java
+++ b/src/main/java/no/nav/svangerskapspenger/domene/søknad/AvklarteDatoer.java
@@ -15,6 +15,7 @@ public class AvklarteDatoer {
     private LocalDate førsteLovligeUttaksdato;
     private LocalDate termindato;
     private LocalDate fødselsdato;
+    private LocalDate startdatoNesteSak;
     private List<Ferie> ferier = new ArrayList<>();
     private LocalDate startOppholdUttak;
 
@@ -44,6 +45,10 @@ public class AvklarteDatoer {
 
     public Optional<LocalDate> getFødselsdato() {
         return Optional.ofNullable(fødselsdato);
+    }
+
+    public Optional<LocalDate> getStartdatoNesteSak() {
+        return Optional.ofNullable(startdatoNesteSak);
     }
 
     public List<Ferie> getFerier() {
@@ -98,6 +103,11 @@ public class AvklarteDatoer {
 
         public Builder medFødselsdato(LocalDate fødselsdato) {
             kladd.fødselsdato = fødselsdato;
+            return this;
+        }
+
+        public Builder medStartdatoNesteSak(LocalDate startdato) {
+            kladd.startdatoNesteSak = startdato;
             return this;
         }
 

--- a/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/FastsettePeriodeRegel.java
+++ b/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/FastsettePeriodeRegel.java
@@ -1,5 +1,12 @@
 package no.nav.svangerskapspenger.regler.fastsettperiode;
 
+import no.nav.fpsak.nare.RuleService;
+import no.nav.fpsak.nare.Ruleset;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.Specification;
+import no.nav.svangerskapspenger.domene.resultat.PeriodeIkkeOppfyltÅrsak;
+import no.nav.svangerskapspenger.domene.resultat.PeriodeOppfyltÅrsak;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkBarnetsDødsdato;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkBrukersDødsdato;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkFerie;
@@ -7,15 +14,9 @@ import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkFødsel
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkFørsteLovligeUttaksdato;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkHullUttak;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkOpphørsdatoForMedlemskap;
+import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkStønadsperiode;
 import no.nav.svangerskapspenger.regler.fastsettperiode.betingelser.SjekkTermindato;
 import no.nav.svangerskapspenger.regler.fastsettperiode.grunnlag.FastsettePeriodeGrunnlag;
-import no.nav.svangerskapspenger.domene.resultat.PeriodeIkkeOppfyltÅrsak;
-import no.nav.svangerskapspenger.domene.resultat.PeriodeOppfyltÅrsak;
-import no.nav.fpsak.nare.RuleService;
-import no.nav.fpsak.nare.Ruleset;
-import no.nav.fpsak.nare.doc.RuleDocumentation;
-import no.nav.fpsak.nare.evaluation.Evaluation;
-import no.nav.fpsak.nare.specification.Specification;
 
 /**
  * Regeltjeneste som fastsetter uttaksperioder som er søkt om for svangerskapspenger.
@@ -39,37 +40,27 @@ public class FastsettePeriodeRegel implements RuleService<FastsettePeriodeGrunnl
     @Override
     public Specification<FastsettePeriodeGrunnlag> getSpecification() {
 
-        var sjekkHull = rs.hvisRegel(SjekkHullUttak.ID, "Er perioden etter et hull uten ytelse?")
-            .hvis(new SjekkHullUttak(), Sluttpunkt.ikkeOppfylt("UT8014", PeriodeIkkeOppfyltÅrsak.PERIODEN_ER_ETTER_ET_OPPHOLD_I_UTTAK))
-            .ellers(Sluttpunkt.oppfylt("UT8011", PeriodeOppfyltÅrsak.UTTAK_ER_INNVILGET));
+        return rs.hvisRegel(ID, "Fastsett periode")
 
-        var sjekkFerie = rs.hvisRegel(SjekkFerie.ID, "Er perioden i en ferieperiode?")
+            .hvis(new SjekkBrukersDødsdato(), Sluttpunkt.ikkeOppfylt("UT8004", PeriodeIkkeOppfyltÅrsak.BRUKER_ER_DØD))
+
+            .hvis(new SjekkBarnetsDødsdato(), Sluttpunkt.ikkeOppfylt("UT8005", PeriodeIkkeOppfyltÅrsak.BARN_ER_DØDT))
+
+            .hvis(new SjekkOpphørsdatoForMedlemskap(), Sluttpunkt.ikkeOppfylt("UT8006", PeriodeIkkeOppfyltÅrsak.BRUKER_ER_IKKE_MEDLEM))
+
+            .hvis(new SjekkFørsteLovligeUttaksdato(), Sluttpunkt.ikkeOppfylt("UT8007", PeriodeIkkeOppfyltÅrsak.SØKT_FOR_SENT))
+
+            .hvis(new SjekkFødselsdato(), Sluttpunkt.ikkeOppfylt("UT8009", PeriodeIkkeOppfyltÅrsak.PERIODEN_ER_IKKE_FØR_FØDSEL))
+
+            .hvis(new SjekkTermindato(), Sluttpunkt.ikkeOppfylt("UT8010", PeriodeIkkeOppfyltÅrsak.PERIODEN_MÅ_SLUTTE_SENEST_TRE_UKER_FØR_TERMIN))
+
+            .hvis(new SjekkStønadsperiode(), Sluttpunkt.ikkeOppfylt("UT8013", PeriodeIkkeOppfyltÅrsak.BEGYNT_ANNEN_SAK))
+
             .hvis(new SjekkFerie(), Sluttpunkt.ikkeOppfylt("UT8012", PeriodeIkkeOppfyltÅrsak.PERIODEN_ER_SAMTIDIG_SOM_EN_FERIE))
-            .ellers(sjekkHull);
 
-        var sjekkTermindato = rs.hvisRegel(SjekkTermindato.ID, "Er perioden på eller etter \"termin minus tre uker\"?")
-                .hvis(new SjekkTermindato(), Sluttpunkt.ikkeOppfylt("UT8010", PeriodeIkkeOppfyltÅrsak.PERIODEN_MÅ_SLUTTE_SENEST_TRE_UKER_FØR_TERMIN))
-                .ellers(sjekkFerie);
+            .hvis(new SjekkHullUttak(), Sluttpunkt.ikkeOppfylt("UT8014", PeriodeIkkeOppfyltÅrsak.PERIODEN_ER_ETTER_ET_OPPHOLD_I_UTTAK))
 
-        var sjekkFødselsdato = rs.hvisRegel(SjekkFødselsdato.ID, "Er fødselsdato kjent og er fødsel minst tre uker før termin og er perioden på eller etter fødselsdato?")
-                .hvis(new SjekkFødselsdato(), Sluttpunkt.ikkeOppfylt("UT8009", PeriodeIkkeOppfyltÅrsak.PERIODEN_ER_IKKE_FØR_FØDSEL))
-                .ellers(sjekkTermindato);
-
-        var sjekkFørsteLovligeUttaksdato = rs.hvisRegel(SjekkFørsteLovligeUttaksdato.ID, "Er perioder før \"gyldig dato\" fra søknadsfrist?")
-                .hvis(new SjekkFørsteLovligeUttaksdato(), Sluttpunkt.ikkeOppfylt("UT8007", PeriodeIkkeOppfyltÅrsak.SØKT_FOR_SENT))
-                .ellers(sjekkFødselsdato);
-
-        var sjekkOpphørsdatoForMedlemskap = rs.hvisRegel(SjekkOpphørsdatoForMedlemskap.ID, "Er perioden på eller etter opphørsdato for medlemskap?")
-                .hvis(new SjekkOpphørsdatoForMedlemskap(), Sluttpunkt.ikkeOppfylt("UT8006", PeriodeIkkeOppfyltÅrsak.BRUKER_ER_IKKE_MEDLEM))
-                .ellers(sjekkFørsteLovligeUttaksdato);
-
-        var sjekkBarnetsDødsdato = rs.hvisRegel(SjekkBarnetsDødsdato.ID, "Er perioden på eller etter barnets/barnes dødsdato?")
-                .hvis(new SjekkBarnetsDødsdato(), Sluttpunkt.ikkeOppfylt("UT8005", PeriodeIkkeOppfyltÅrsak.BARN_ER_DØDT))
-                .ellers(sjekkOpphørsdatoForMedlemskap);
-
-        return rs.hvisRegel(SjekkBrukersDødsdato.ID, "Er perioden på eller etter brukers dødsdato?")
-                .hvis(new SjekkBrukersDødsdato(), Sluttpunkt.ikkeOppfylt("UT8004", PeriodeIkkeOppfyltÅrsak.BRUKER_ER_DØD))
-                .ellers(sjekkBarnetsDødsdato);
+            .ellers(Sluttpunkt.oppfylt("UT8011", PeriodeOppfyltÅrsak.UTTAK_ER_INNVILGET));
     }
 
 }

--- a/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkHullUttak.java
+++ b/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkHullUttak.java
@@ -10,7 +10,7 @@ import no.nav.svangerskapspenger.regler.fastsettperiode.grunnlag.FastsettePeriod
 @RuleDocumentation(SjekkHullUttak.ID)
 public class SjekkHullUttak extends LeafSpecification<FastsettePeriodeGrunnlag> {
 
-    public static final String ID = "SVP_VK_14.4.9";
+    public static final String ID = "SVP_VK 14.4.9";
 
     public SjekkHullUttak() {
         super(ID);

--- a/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkStønadsperiode.java
+++ b/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkStønadsperiode.java
@@ -1,0 +1,30 @@
+package no.nav.svangerskapspenger.regler.fastsettperiode.betingelser;
+
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+import no.nav.svangerskapspenger.regler.fastsettperiode.grunnlag.FastsettePeriodeGrunnlag;
+
+@RuleDocumentation(SjekkStønadsperiode.ID)
+public class SjekkStønadsperiode extends LeafSpecification<FastsettePeriodeGrunnlag> {
+
+    public static final String ID = "SVP_VK 14.4.10";
+
+    public SjekkStønadsperiode() {
+        super(ID);
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+
+        if (grunnlag.getAvklarteDatoer().getStartdatoNesteSak().isPresent()) {
+            var startUttaksperiode = grunnlag.getAktuellPeriode().getFom();
+            var startNesteSak = grunnlag.getAvklarteDatoer().getStartdatoNesteSak().get();
+            if (startUttaksperiode.equals(startNesteSak) || startUttaksperiode.isAfter(startNesteSak)) {
+                return ja();
+            }
+        }
+        return nei();
+    }
+
+}

--- a/src/main/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjeneste.java
+++ b/src/main/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjeneste.java
@@ -95,6 +95,7 @@ public class FastsettPerioderTjeneste {
         avklarteDatoer.getOpphørsdatoForMedlemskap().ifPresent(knekkpunkter::add);
         avklarteDatoer.getFørsteLovligeUttaksdato().ifPresent(knekkpunkter::add);
         knekkpunkter.add(avklarteDatoer.getTerminsdato().minusWeeks(3));
+        avklarteDatoer.getStartdatoNesteSak().ifPresent(knekkpunkter::add);
         avklarteDatoer.getFødselsdato().ifPresent(knekkpunkter::add);
         avklarteDatoer.getBrukersDødsdato().ifPresent(knekkpunkter::add);
         avklarteDatoer.getBarnetsDødsdato().ifPresent(knekkpunkter::add);


### PR DESCRIPTION
Gliphy på SVP-dok-sidene
- ny stønadsperiode (annen SVP-sak eller FP) kommer inn fra avklartedatoer
- tatt inn regel om å avslå pga evt ny stønadsperiode 
- knekker perioder på evt ny stønadsperiode 
- Skrevet om Gap-check til timeline og rettet fom/tom for ferie
