### PR TITLE
TFP-5873 Ta inn medlemsvilkår i regelevaluering

### DIFF
--- a/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkOpphørsdatoForMedlemskap.java
+++ b/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/betingelser/SjekkOpphørsdatoForMedlemskap.java
@@ -1,6 +1,8 @@
 package no.nav.svangerskapspenger.regler.fastsettperiode.betingelser;
 
 
+import java.util.Objects;
+
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
@@ -17,6 +19,10 @@ public class SjekkOpphørsdatoForMedlemskap extends LeafSpecification<FastsetteP
 
     @Override
     public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+        // Kompatibel med eldre grunnlag v/deserialisering - vil gå videre dersom true eller null
+        if (Objects.equals(grunnlag.getInngangsvilkår().medlemskapOppfylt(), Boolean.FALSE)) {
+            return ja();
+        }
         return grunnlag.getAvklarteDatoer().getOpphørsdatoForMedlemskap().map(opphørsdatoForMedlemskap -> {
             var startUttaksperiode = grunnlag.getAktuellPeriode().getFom();
             return startUttaksperiode.equals(opphørsdatoForMedlemskap) || startUttaksperiode.isAfter(opphørsdatoForMedlemskap) ? ja() : nei();

--- a/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/grunnlag/Inngangsvilkår.java
+++ b/src/main/java/no/nav/svangerskapspenger/regler/fastsettperiode/grunnlag/Inngangsvilkår.java
@@ -1,4 +1,4 @@
 package no.nav.svangerskapspenger.regler.fastsettperiode.grunnlag;
 
-public record Inngangsvilkår (boolean opptjeningOppfylt, boolean manueltSVPVilkårOppfylt ) {
+public record Inngangsvilkår (boolean opptjeningOppfylt, boolean manueltSVPVilkårOppfylt, Boolean medlemskapOppfylt) {
 }

--- a/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjenesteTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjenesteTest.java
@@ -47,7 +47,7 @@ public class FastsettPerioderTjenesteTest {
 
     private final FastsettPerioderTjeneste fastsettPerioderTjeneste = new FastsettPerioderTjeneste();
 
-    private final Inngangsvilkår inngangsvilkårDefault = new Inngangsvilkår(true, true);
+    private final Inngangsvilkår inngangsvilkårDefault = new Inngangsvilkår(true, true, Boolean.TRUE);
 
     @Test
     public void ingen_tilrettelegging_fra_behovsdato() {
@@ -666,7 +666,7 @@ public class FastsettPerioderTjenesteTest {
             List.of(
                 new IngenTilrettelegging(LocalDate.of(2019, Month.JANUARY, 1))
             )));
-        var avslåttInngangsvilgår = new Inngangsvilkår(false, true);
+        var avslåttInngangsvilgår = new Inngangsvilkår(false, true, Boolean.TRUE);
         var uttaksperioder = fastsettPerioderTjeneste.fastsettePerioder(nyeSøknader, avklarteDatoer, avslåttInngangsvilgår, Map.of(ARBEIDSFORHOLD1, oppholdListe));
 
         var perioder = uttaksperioder.perioder(ARBEIDSFORHOLD1).getUttaksperioder();
@@ -688,7 +688,7 @@ public class FastsettPerioderTjenesteTest {
             List.of(
                 new IngenTilrettelegging(LocalDate.of(2019, Month.JANUARY, 1))
             )));
-        var avslåttInngangsvilgår = new Inngangsvilkår(true, false);
+        var avslåttInngangsvilgår = new Inngangsvilkår(true, false, Boolean.TRUE);
         var uttaksperioder = fastsettPerioderTjeneste.fastsettePerioder(nyeSøknader, avklarteDatoer, avslåttInngangsvilgår, Map.of(ARBEIDSFORHOLD1, oppholdListe));
 
         var perioder = uttaksperioder.perioder(ARBEIDSFORHOLD1).getUttaksperioder();


### PR DESCRIPTION
Sikring for at SVP-perioder avslås dersom medlemsvilkåret er avslått
Beholder opphørFom-logikk (selv om den ikke har slått til siden 2019).