### PR TITLE
revert: TFP-6942 fjern flagget arbeidsforholdErSplittet

### DIFF
--- a/src/main/java/no/nav/svangerskapspenger/domene/felles/Arbeidsforhold.java
+++ b/src/main/java/no/nav/svangerskapspenger/domene/felles/Arbeidsforhold.java
@@ -9,30 +9,26 @@ public class Arbeidsforhold {
     private final String arbeidsgiverVirksomhetId;
     private final String arbeidsgiverAktørId;
     private final String arbeidsforholdId;
-    private final boolean arbeidsforholdErSplittet;
 
-    private Arbeidsforhold(AktivitetType aktivitetType, String arbeidsgiverVirksomhetId, String arbeidsgiverAktørId, String arbeidsforholdId,
-                           boolean arbeidsforholdErSplittet) {
+    private Arbeidsforhold(AktivitetType aktivitetType, String arbeidsgiverVirksomhetId, String arbeidsgiverAktørId, String arbeidsforholdId) {
         this.aktivitetType = aktivitetType;
         this.arbeidsgiverVirksomhetId = arbeidsgiverVirksomhetId;
         this.arbeidsgiverAktørId = arbeidsgiverAktørId;
         this.arbeidsforholdId = arbeidsforholdId;
-        this.arbeidsforholdErSplittet = arbeidsforholdErSplittet;
     }
 
-    public static Arbeidsforhold virksomhet(AktivitetType aktivitetType, String arbeidsgiverVirksomhetId, String arbeidsforholdId,
-                                            boolean arbeidsforholdErSplittet) {
+    public static Arbeidsforhold virksomhet(AktivitetType aktivitetType, String arbeidsgiverVirksomhetId, String arbeidsforholdId) {
         Objects.requireNonNull(arbeidsgiverVirksomhetId);
-        return new Arbeidsforhold(aktivitetType, arbeidsgiverVirksomhetId, null, arbeidsforholdId, arbeidsforholdErSplittet);
+        return new Arbeidsforhold(aktivitetType, arbeidsgiverVirksomhetId, null, arbeidsforholdId);
     }
 
     public static Arbeidsforhold aktør(AktivitetType aktivitetType, String arbeidsgiverAktørId, String arbeidsforholdId) {
         Objects.requireNonNull(arbeidsgiverAktørId);
-        return new Arbeidsforhold(aktivitetType, null, arbeidsgiverAktørId, arbeidsforholdId, false);
+        return new Arbeidsforhold(aktivitetType, null, arbeidsgiverAktørId, arbeidsforholdId);
     }
 
     public static Arbeidsforhold annet(AktivitetType aktivitetType) {
-        return new Arbeidsforhold(aktivitetType, null, null, null, false);
+        return new Arbeidsforhold(aktivitetType, null, null, null);
     }
 
     public String getArbeidsgiverVirksomhetId() {
@@ -51,10 +47,6 @@ public class Arbeidsforhold {
         return aktivitetType;
     }
 
-    public boolean getArbeidsforholdErSplittet() {
-        return arbeidsforholdErSplittet;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -63,12 +55,11 @@ public class Arbeidsforhold {
         return aktivitetType == that.aktivitetType &&
             Objects.equals(arbeidsgiverVirksomhetId, that.arbeidsgiverVirksomhetId) &&
             Objects.equals(arbeidsgiverAktørId, that.arbeidsgiverAktørId) &&
-            Objects.equals(arbeidsforholdId, that.arbeidsforholdId) &&
-            Objects.equals(arbeidsforholdErSplittet, that.arbeidsforholdErSplittet);
+            Objects.equals(arbeidsforholdId, that.arbeidsforholdId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aktivitetType, arbeidsgiverVirksomhetId, arbeidsgiverAktørId, arbeidsforholdId,  arbeidsforholdErSplittet);
+        return Objects.hash(aktivitetType, arbeidsgiverVirksomhetId, arbeidsgiverAktørId, arbeidsforholdId);
     }
 }

--- a/src/test/java/no/nav/svangerskapspenger/domene/resultat/UttaksperioderTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/domene/resultat/UttaksperioderTest.java
@@ -17,7 +17,7 @@ class UttaksperioderTest {
 
     @Test
     void riktig_start_og_slutt_dato_med_en_periode() {
-        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
         var uttaksperioder = new Uttaksperioder();
         uttaksperioder.leggTilPerioder(arbeidsforhold,
             new Uttaksperiode(LocalDate.of(2019, Month.JANUARY, 1), LocalDate.of(2019, Month.JANUARY, 31), FULL_UTBETALING));
@@ -28,8 +28,8 @@ class UttaksperioderTest {
 
     @Test
     void riktig_start_og_slutt_dato_med_perioder_på_forskjellige_arbeidsforhold() {
-        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
-        var arbeidsforhold2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "234", "567", false);
+        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
+        var arbeidsforhold2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "234", "567");
         var uttaksperioder = new Uttaksperioder();
         uttaksperioder.leggTilPerioder(arbeidsforhold1,
             new Uttaksperiode(LocalDate.of(2019, Month.JANUARY, 1), LocalDate.of(2019, Month.JANUARY, 31), FULL_UTBETALING));
@@ -42,7 +42,7 @@ class UttaksperioderTest {
 
     @Test
     void ingen_start_og_slutt_dato_dersom_avslag_på_arbeidsforhold() {
-        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
         var uttaksperioder = new Uttaksperioder();
         uttaksperioder.leggTilPerioder(arbeidsforhold,
             new Uttaksperiode(LocalDate.of(2019, Month.JANUARY, 1), LocalDate.of(2019, Month.JANUARY, 31), FULL_UTBETALING));
@@ -63,7 +63,7 @@ class UttaksperioderTest {
     @Test
     void skal_være_mulig_å_legge_til_perioder() {
         var uttaksperioder = new Uttaksperioder();
-        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
 
         uttaksperioder.leggTilPerioder(arbeidsforhold, new Uttaksperiode(LocalDate.of(2019, Month.JANUARY, 1), LocalDate.of(2019, Month.JANUARY, 31), FULL_UTBETALING));
         uttaksperioder.leggTilPerioder(arbeidsforhold,

--- a/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjenesteTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/FastsettPerioderTjenesteTest.java
@@ -28,14 +28,14 @@ import no.nav.svangerskapspenger.regler.fastsettperiode.grunnlag.Inngangsvilkår
 
 class FastsettPerioderTjenesteTest {
 
-    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
     private static final BigDecimal ARBEIDSFORHOLD1_PROSENT = BigDecimal.valueOf(100L);
-    private static final Arbeidsforhold ARBEIDSFORHOLD2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "234", "567", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "234", "567");
     private static final BigDecimal ARBEIDSFORHOLD2_PROSENT = BigDecimal.valueOf(100L);
 
-    private static final Arbeidsforhold ARBEIDSFORHOLD3 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "345", "1", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD3 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "345", "1");
     private static final BigDecimal ARBEIDSFORHOLD3_PROSENT = BigDecimal.valueOf(60L);
-    private static final Arbeidsforhold ARBEIDSFORHOLD4 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "345", "2", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD4 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "345", "2");
     private static final BigDecimal ARBEIDSFORHOLD4_PROSENT = BigDecimal.valueOf(40L);
 
     private static final BigDecimal FULL_UTBETALINGSGRAD = BigDecimal.valueOf(100L);

--- a/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/UttakHullUtlederTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/tjeneste/fastsettuttak/UttakHullUtlederTest.java
@@ -19,7 +19,7 @@ class UttakHullUtlederTest {
 
     @Test
     void enkelt_uttak_med_et_arbeidsforhold_uten_hull() {
-        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null, false);
+        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null);
 
         var perioder = new Uttaksperioder();
         perioder.leggTilPerioder(arb1,
@@ -35,7 +35,7 @@ class UttakHullUtlederTest {
 
     @Test
     void enkelt_uttak_med_et_arbeidsforhold_med_hull() {
-        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null, false);
+        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null);
 
         var perioder = new Uttaksperioder();
         perioder.leggTilPerioder(arb1,
@@ -52,11 +52,11 @@ class UttakHullUtlederTest {
     @Test
     void komplekst_uttak_med_flere_arbeidsforhold_uten_hull() {
 
-        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null, false);
-        var arb2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "2", null, false);
-        var arb3 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "3", null, false);
-        var arb4 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "4", null, false);
-        var arb5 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "5", null, false);
+        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null);
+        var arb2 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "2", null);
+        var arb3 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "3", null);
+        var arb4 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "4", null);
+        var arb5 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "5", null);
 
         var perioder = new Uttaksperioder();
         perioder.leggTilPerioder(arb1,
@@ -100,7 +100,7 @@ class UttakHullUtlederTest {
 
     @Test
     void overlappende_ferie_midt_i_periode_med_0_utbetaling_skal_ikke_gi_hull() {
-        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null, false);
+        var arb1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "1", null);
 
         var perioder = new Uttaksperioder();
         perioder.leggTilPerioder(arb1,

--- a/src/test/java/no/nav/svangerskapspenger/tjeneste/opprettperioder/UtbetalingsgradUtlederTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/tjeneste/opprettperioder/UtbetalingsgradUtlederTest.java
@@ -16,7 +16,7 @@ import no.nav.svangerskapspenger.domene.søknad.Søknad;
 
 class UtbetalingsgradUtlederTest {
 
-    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
 
     private static final LocalDate TERMINDATO = LocalDate.of(2019, Month.MAY, 1);
     private static final LocalDate BEHOVDATO = LocalDate.of(2019, Month.JANUARY, 1);

--- a/src/test/java/no/nav/svangerskapspenger/tjeneste/opprettperioder/UttaksperioderTjenesteTest.java
+++ b/src/test/java/no/nav/svangerskapspenger/tjeneste/opprettperioder/UttaksperioderTjenesteTest.java
@@ -22,7 +22,7 @@ class UttaksperioderTjenesteTest {
 
     private static final BigDecimal HUNDRE_PROSENT = BigDecimal.valueOf(100L);
 
-    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456", false);
+    private static final Arbeidsforhold ARBEIDSFORHOLD1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123", "456");
     private static final LocalDate TERMINDATO = LocalDate.of(2019, Month.MAY, 1);
 
     private final UttaksperioderTjeneste uttaksperioderTjeneste = new UttaksperioderTjeneste();


### PR DESCRIPTION
## Sammendrag
- Reverter endringen fra TFP-6942 som la til flagget `arbeidsforholdErSplittet`

## Validering
- Revert av eksisterende commit
