### PR TITLE
fix: revert fp-tidsserie til 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <fpsak.nare.version>2.6.4</fpsak.nare.version>
-        <fpsak.tidsserie.version>2.7.5</fpsak.tidsserie.version>
+        <fpsak.tidsserie.version>2.7.4</fpsak.tidsserie.version>
 
         <!-- Sonar felles -->
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>


### PR DESCRIPTION
fp-tidsserie 2.7.5 introduserte en bug i LocalDateTimeline.combine()/ intersection() (KnekkpunktIterator) der kombinering av to tidslinjer som begge har et segment åpent til LocalDate.MAX gir feil eller tomt resultat for JoinStyle INNER_JOIN, RIGHT_JOIN, CROSS_JOIN og LEFT_JOIN.

Reverter til siste kjente gode versjon inntil fikset er verifisert oppstrøms.